### PR TITLE
Update Vue.js example to computed properties instead of watch.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,18 +21,13 @@ MobX is also seperated from any rendering or component initialization, unlike in
 Vue
 ```
 var vm = new Vue({
-  el: '#demo',
   data: {
     firstName: 'Foo',
-    lastName: 'Bar',
-    fullName: 'Foo Bar'
+    lastName: 'Bar'
   },
-  watch: {
-    firstName: function (val) {
-      this.fullName = val + ' ' + this.lastName
-    },
-    lastName: function (val) {
-      this.fullName = this.firstName + ' ' + val
+  computed: {
+    fullName: function () {
+      return this.firstName + ' ' + this.lastName
     }
   }
 })


### PR DESCRIPTION
The first example was a bit misleading, because it used watch instead computed properties and added 'el' which is not required until you know where you will mount the instance. Now the two examples are more alike and accomplish the same basic thing.

You can see for the difference between watch and computed http://vuejs.org/guide/computed.html#Computed-vs-Watched-Property .
